### PR TITLE
fix: change how billing are calculated

### DIFF
--- a/apps/hub/src/domains/game/components/game-billing/game-billing-context.tsx
+++ b/apps/hub/src/domains/game/components/game-billing/game-billing-context.tsx
@@ -18,6 +18,7 @@ interface GameBillingContextValue {
     used: number;
     overage: number;
     remaining: number;
+    total: number;
   };
   subscription: RivetEe.ee.billing.Subscription | undefined;
 }

--- a/apps/hub/src/domains/game/components/game-billing/game-billing-plans.tsx
+++ b/apps/hub/src/domains/game/components/game-billing/game-billing-plans.tsx
@@ -18,6 +18,7 @@ import {
   faShield,
   faUpRightAndDownLeftFromCenter,
 } from "@rivet-gg/icons";
+import { PRICE_MAP } from "../../data/billing-calculate-usage";
 import {
   LobbyRegionIcon,
   LobbyRegionName,
@@ -46,7 +47,7 @@ export function GameBillingPlans({ gameId }: GameBillingPlansProps) {
         <GameBillingPlanCard
           title="Indie"
           lead="Fixed price suitable for indies & hobbyists"
-          price="$9"
+          price={`$${PRICE_MAP[RivetEe.ee.billing.Plan.Indie]}`}
           onSubscribe={() =>
             open({
               plan: RivetEe.ee.billing.Plan.Indie,
@@ -118,7 +119,7 @@ export function GameBillingPlans({ gameId }: GameBillingPlansProps) {
               plan: RivetEe.ee.billing.Plan.Trial,
             })
           }
-          price="$29"
+          price={`$${PRICE_MAP[RivetEe.ee.billing.Plan.Studio]}`}
           type={plan === RivetEe.ee.billing.Plan.Studio ? "active" : undefined}
           priceLead="+ Resource Usage"
           features={[

--- a/apps/hub/src/domains/game/components/game-billing/game-billing-summary.tsx
+++ b/apps/hub/src/domains/game/components/game-billing/game-billing-summary.tsx
@@ -3,14 +3,14 @@ import { useGameBilling } from "./game-billing-context";
 
 export function GameBillingSummary() {
   const {
-    credits: { overage, remaining },
+    credits: { total, remaining },
   } = useGameBilling();
 
   return (
     <Grid columns={{ initial: "1", md: "3" }} gap="4">
       <ValueCard
         title="Current bill total"
-        value={<AnimatedCurrency value={overage} />}
+        value={<AnimatedCurrency value={total} />}
       />
       <ValueCard
         title="Credits remaining"

--- a/apps/hub/src/domains/game/data/billing-calculate-usage.ts
+++ b/apps/hub/src/domains/game/data/billing-calculate-usage.ts
@@ -1,6 +1,11 @@
 import { Rivet as RivetEe } from "@rivet-gg/api-ee";
 import { millisecondsToMonths } from "@rivet-gg/components";
 
+export const PRICE_MAP = {
+  [RivetEe.ee.billing.Plan.Trial]: 0,
+  [RivetEe.ee.billing.Plan.Indie]: 9.0,
+  [RivetEe.ee.billing.Plan.Studio]: 29.0,
+};
 const CREIDTS_MAP = {
   [RivetEe.ee.billing.Plan.Trial]: 5.0,
   [RivetEe.ee.billing.Plan.Indie]: 48.21,
@@ -25,10 +30,13 @@ export function calculateUsedCredits({
   const monthsOfUptime = millisecondsToMonths(totalUptime);
   const usedCredits = monthsOfUptime * FACTOR;
 
+  const overage = Math.max(0, usedCredits - CREIDTS_MAP[plan]);
+
   return {
     max: CREIDTS_MAP[plan],
     used: usedCredits,
     remaining: CREIDTS_MAP[plan] - usedCredits,
-    overage: Math.max(0, usedCredits - CREIDTS_MAP[plan]),
+    overage,
+    total: PRICE_MAP[plan] + overage,
   };
 }


### PR DESCRIPTION
Closes CON-70

### TL;DR

Updated billing calculations and display for game plans.

### What changed?

- Added a `total` field to the `GameBillingContextValue` interface
- Updated `GameBillingPlans` component to use dynamic pricing from `PRICE_MAP`
- Modified `GameBillingSummary` to display the total bill instead of overage
- Introduced `PRICE_MAP` in `billing-calculate-usage.ts` for plan pricing
- Updated `calculateUsedCredits` function to include total bill calculation

### How to test?

1. Navigate to the game billing section
2. Verify that the pricing for Indie and Studio plans is correctly displayed
3. Check that the "Current bill total" in the billing summary shows the correct total (base plan price + overage)
4. Test different usage scenarios to ensure the total bill is calculated correctly

### Why make this change?

This change improves the accuracy and clarity of billing information for users. By introducing dynamic pricing and displaying the total bill (including the base plan price), users can better understand their current charges and make informed decisions about their subscription plans.