### PR TITLE
fix: change servers page wording

### DIFF
--- a/apps/hub/src/routes/_authenticated/_layout/games/$gameId_/environments/$namespaceId/servers/index.tsx
+++ b/apps/hub/src/routes/_authenticated/_layout/games/$gameId_/environments/$namespaceId/servers/index.tsx
@@ -64,7 +64,9 @@ function GameServersRoute() {
       <CardContent className="flex-1 min-h-0 w-full p-0">
         {data.length === 0 ? (
           <div className="flex items-center mx-auto flex-col gap-2 my-10">
-            <Text textAlign="center">No servers found.</Text>
+            <Text textAlign="center">
+              Servers will be created automatically when players join.
+            </Text>
           </div>
         ) : (
           <GameServersListPreview


### PR DESCRIPTION
Closes CON-69

### TL;DR

Updated the message displayed when no servers are found in the game environment.

### What changed?

Modified the text shown to users when there are no servers in the game environment. Instead of simply stating "No servers found.", the new message informs users that "Servers will be created automatically when players join."

### How to test?

1. Navigate to a game environment with no active servers.
2. Verify that the new message "Servers will be created automatically when players join." is displayed in the server list area.

### Why make this change?

This change provides more informative feedback to users, explaining the automatic server creation process when players join. It helps set expectations and reduces potential confusion about why no servers are initially visible in the environment.