### PR TITLE
fix: append servers logs when watching

### DIFF
--- a/apps/hub/src/domains/game/queries/dynamic-servers/query-options.ts
+++ b/apps/hub/src/domains/game/queries/dynamic-servers/query-options.ts
@@ -1,6 +1,7 @@
 import { rivetClient } from "@/queries/global";
 import { getMetaWatchIndex } from "@/queries/utils";
 import type { Rivet } from "@rivet-gg/api";
+import * as RivetSerialization from "@rivet-gg/api/serialization";
 import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 
 export const gameServersQueryOptions = ({
@@ -111,6 +112,24 @@ export const serverLogsQueryOptions = (
       ...data,
       lines: data.lines.map((line) => window.atob(line)),
     }),
+    structuralSharing: (oldData, newData) => {
+      const newParsed =
+        RivetSerialization.servers.logs.GetServerLogsResponse.parse(newData);
+      const oldParsed =
+        RivetSerialization.servers.logs.GetServerLogsResponse.parse(oldData);
+
+      if (newParsed.ok && oldParsed.ok) {
+        return {
+          ...newParsed,
+          timestamps: [
+            ...oldParsed.value.timestamps,
+            ...newParsed.value.timestamps,
+          ],
+          lines: [...oldParsed.value.lines, ...newParsed.value.lines],
+        };
+      }
+      return newData;
+    },
     meta: {
       watch: true,
     },


### PR DESCRIPTION
Closes HUB-497

### TL;DR

Enhanced server logs query options with structural sharing for improved performance.

### What changed?

- Added `rivetSerialization` import from "@rivet-gg/api/serialization"
- Implemented `structuralSharing` function in `serverLogsQueryOptions`
- The new function parses old and new data, combining timestamps and lines if both are valid

### How to test?

1. Navigate to the server logs section in the application
2. Observe the logs loading and updating
3. Verify that new log entries are appended correctly without duplicates
4. Check for any performance improvements in log rendering, especially with large datasets

### Why make this change?

This change optimizes the handling of server logs by implementing structural sharing. It ensures that new log data is efficiently merged with existing data, reducing unnecessary re-renders and improving overall performance when dealing with large volumes of log entries. This enhancement is particularly beneficial for long-running servers or during intensive debugging sessions.