### PR TITLE
feat: add `BASE_URL` support

### DIFF
--- a/apps/hub/src/app.tsx
+++ b/apps/hub/src/app.tsx
@@ -27,6 +27,7 @@ declare module "@tanstack/react-router" {
 }
 
 export const router = createRouter({
+  basepath: import.meta.env.BASE_URL,
   routeTree,
   routeMasks,
   context: {


### PR DESCRIPTION
Closes FRONT-524

Run from the root folder: 
```bash
yarn build -- --base=/your/desired/path
```

for more information, check out: https://vite.dev/guide/build.html#public-base-path, and https://vite.dev/config/shared-options.html#base